### PR TITLE
Made changes to add start elasticsearch command

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -43,7 +43,7 @@ CMD /opt/elasticsearch/scripts/start.sh
 
 COPY --from=builder /opt/elasticsearch-2.3.3/ /opt/elasticsearch/
 
-COPY scripts / /opt/elasticsearch/scripts/
+COPY scripts/ /opt/elasticsearch/scripts/
 RUN chmod +x /opt/elasticsearch/scripts/*
 
 # Tag the image

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -39,9 +39,12 @@ RUN zypper -n install which hostname
 
 # Startup Elasticsearch and expose ports
 EXPOSE 9200 9300
-CMD /opt/elasticsearch/bin/elasticsearch -Des.insecure.allow.root=true
+CMD /opt/elasticsearch/scripts/start.sh
 
 COPY --from=builder /opt/elasticsearch-2.3.3/ /opt/elasticsearch/
+
+COPY scripts / /opt/elasticsearch/scripts/
+RUN chmod +x /opt/elasticsearch/scripts/*
 
 # Tag the image
 ARG BUILD_NUMBER

--- a/src/main/docker/scripts/start.sh
+++ b/src/main/docker/scripts/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+exec /opt/elasticsearch/bin/elasticsearch -Des.insecure.allow.root=true


### PR DESCRIPTION
Tested this in the following dev builds:
http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/view/Developer/job/CAFDataProcessing~policy-elasticsearch-container~start_es~CI/

http://sou-jenkins2.hpeswlab.net/job/caf/view/Developer/job/caf~worker-data-processing-internal~CAF-3862~CI/

http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/view/Developer/job/CAFDataProcessing~worker-policy~CAF-3862~CI/

http://sou-jenkins2.hpeswlab.net/job/Verity/view/Developer/job/Verity~worker-classification~CAF-3862~CI/